### PR TITLE
GIF canvas set to transparent if bg color is undefined (zeroed)

### DIFF
--- a/src/extra/libs/gif/gifdec.c
+++ b/src/extra/libs/gif/gifdec.c
@@ -137,7 +137,7 @@ static gd_GIF * gif_open(gd_GIF * gif_base)
         memset(gif->frame, gif->bgindex, gif->width * gif->height);
     bgcolor = &gif->palette->colors[gif->bgindex*3];
 
-    if (bgcolor[0] || bgcolor[1] || bgcolor [2]){
+    if (bgcolor[0] || bgcolor[1] || bgcolor [2])
         for (i = 0; i < gif->width * gif->height; i++) {
 #if LV_COLOR_DEPTH == 32
             gif->canvas[i*4 + 0] = *(bgcolor + 2);
@@ -155,17 +155,6 @@ static gd_GIF * gif_open(gd_GIF * gif_base)
             gif->canvas[i*2 + 1] = 0xff;
 #endif
         }
-	}else{
-			for (i = 0; i < gif->width * gif->height; i++) {
-#if LV_COLOR_DEPTH == 32
-			gif->canvas[i*4 + 3] = 0x00;
-#elif LV_COLOR_DEPTH == 16
-			gif->canvas[i*3 + 2] = 0x00;
-#elif LV_COLOR_DEPTH == 8
-			gif->canvas[i*2 + 1] = 0x00;
-#endif
-			}
-		}
     gif->anim_start = f_gif_seek(gif, 0, LV_FS_SEEK_CUR);
     goto ok;
 fail:

--- a/src/extra/libs/gif/gifdec.c
+++ b/src/extra/libs/gif/gifdec.c
@@ -120,6 +120,9 @@ static gd_GIF * gif_open(gd_GIF * gif_base)
     gif->width  = width;
     gif->height = height;
     gif->depth  = depth;
+
+	gif->firstClear = true;
+
     /* Read GCT */
     gif->gct.size = gct_sz;
     f_gif_read(gif, gif->gct.colors, 3 * gif->gct.size);
@@ -216,6 +219,19 @@ read_graphic_control_ext(gd_GIF *gif)
     f_gif_read(gif, &gif->gce.tindex, 1);
     /* Skip block terminator. */
     f_gif_seek(gif, 1, LV_FS_SEEK_CUR);
+
+	if(gif->firstClear && gif->gce.transparency){
+		gif->firstClear = false;
+		for (size_t i = 0; i < gif->width * gif->height; i++) {
+#if LV_COLOR_DEPTH == 32
+			gif->canvas[i*4 + 3] = 0x00;
+#elif LV_COLOR_DEPTH == 16
+			gif->canvas[i*3 + 2] = 0x00;
+#elif LV_COLOR_DEPTH == 8
+			gif->canvas[i*2 + 1] = 0x00;
+#endif
+		}
+	}
 }
 
 static void

--- a/src/extra/libs/gif/gifdec.c
+++ b/src/extra/libs/gif/gifdec.c
@@ -137,7 +137,7 @@ static gd_GIF * gif_open(gd_GIF * gif_base)
         memset(gif->frame, gif->bgindex, gif->width * gif->height);
     bgcolor = &gif->palette->colors[gif->bgindex*3];
 
-    if (bgcolor[0] || bgcolor[1] || bgcolor [2])
+    if (bgcolor[0] || bgcolor[1] || bgcolor [2]){
         for (i = 0; i < gif->width * gif->height; i++) {
 #if LV_COLOR_DEPTH == 32
             gif->canvas[i*4 + 0] = *(bgcolor + 2);
@@ -155,6 +155,17 @@ static gd_GIF * gif_open(gd_GIF * gif_base)
             gif->canvas[i*2 + 1] = 0xff;
 #endif
         }
+	}else{
+			for (i = 0; i < gif->width * gif->height; i++) {
+#if LV_COLOR_DEPTH == 32
+			gif->canvas[i*4 + 3] = 0x00;
+#elif LV_COLOR_DEPTH == 16
+			gif->canvas[i*3 + 2] = 0x00;
+#elif LV_COLOR_DEPTH == 8
+			gif->canvas[i*2 + 1] = 0x00;
+#endif
+			}
+		}
     gif->anim_start = f_gif_seek(gif, 0, LV_FS_SEEK_CUR);
     goto ok;
 fail:

--- a/src/extra/libs/gif/gifdec.h
+++ b/src/extra/libs/gif/gifdec.h
@@ -43,6 +43,8 @@ typedef struct gd_GIF {
     uint16_t fx, fy, fw, fh;
     uint8_t bgindex;
     uint8_t *canvas, *frame;
+
+	bool firstClear;
 } gd_GIF;
 
 gd_GIF * gd_open_gif_file(const char *fname);


### PR DESCRIPTION
GIF canvas je sada postavljen na transparent ako gif ima crni background color, jer tako izgleda GIF header kada u nekom programu npr. Asepriteu napraviš i exportaš transparentni gif.

GIF transparencija je zapravo u GIF specifikaciji uređena jednim blokom (Graphic Control Extension) u headeru koji je opcionalan(!) i zato sam mislio da je ovo ispravno rješenje.

Loša strana ovoga je da se crni background nikad neće moći nacrtati, ali će ovo ipak raditi za svaki GIF, bez obzira ima li Graphic Control Extension ili ne (barem za verziju 89a). Ako koristimo lvgl i želiš crni background morat ćeš za svoj lv_gif_obj postaviti 
lv_obj_set_bg_color( ... lv_color_black(), ...);

To nije ništa komplicirano, ali možda će neki GIF iz starih proizvoda zapravo očekivati crni background na GIF-u. Sad bi trebalo proći kroz sve upotrebe lv_gifa i uvjeriti se da nema tog slučaja.

Možeš probati sa Main screenom BatControllera, stavi ovaj lib u platformu umjesto postojećeg lvgl liba.